### PR TITLE
Improved compatibility with older versions of Windows Server

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -38,6 +38,13 @@ if (-not $isAdmin) {
     exit
 }
 
+# Make sure older versions of PowerShell are configured to allow TLS 1.2
+# OSVersion needs to be considered to prevent downgrading stronger SystemDefault on newer versions of Windows Server
+$commonSecurityProtocols = [Net.SecurityProtocolType]::Tls12
+if ([System.Environment]::OSVersion.Version.Build -lt 17763 -and [Net.ServicePointManager]::SecurityProtocol -lt $commonSecurityProtocols) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $commonSecurityProtocols
+}
+
 # Find and uninstall v1 agent
 Write-Host "Checking for old agent..."
 $processName = "HetrixToolsAgent.exe"


### PR DESCRIPTION
We need to use the agent with Server 2016 and Powershell 5.1.

Installation fails because `install.ps1` is unable to download `hetrixtools_agent.ps1` and `hetrixtools.cfg`. The downloads fail because Powershell 5.1 defaults to weak SecurityProtocols that are unsupported by `raw.githubusercontent.com`. Tls 1.2 is supported by both, but has to be enabled manually in Powershell 5.1.

This change adds an if-block below the is64BitOS and isAdmin checks. The condition determines if the operating system predates Server 2019 and enabled SecurityProtocols are less than Tls 1.2. The command enables Tls 1.2 in SecurityProtocol via bitwise or.

See also:
- [SecurityProtocolType Enum on older versions of Windows Server](https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.5)
- [SecurityProtocolType Enum](https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-9.0)